### PR TITLE
Make recursive-narrow-or-widen-dwim more configurable

### DIFF
--- a/recursive-narrow.el
+++ b/recursive-narrow.el
@@ -98,6 +98,15 @@ Performs the exact same function but also allows
   (interactive "r")
 	(recursive-narrow-save-position (narrow-to-region start end)))
 
+(defun recursive-narrow-to-defun (&optional arg)
+  "Replacement of `narrow-to-defun'.
+Performs the exact same function but also allows
+`recursive-widen' to remove just one call to
+`recursive-narrow-to-region'. Optional ARG is ignored."
+  (interactive)
+	(recursive-narrow-save-position
+	 (narrow-to-defun)))
+
 (defun recursive-widen ()
   "Replacement of widen that will only pop one level of visibility."
   (interactive)
@@ -111,6 +120,7 @@ Performs the exact same function but also allows
           (narrow-to-region (car widen-to) (cdr widen-to))
           (recenter))
       (widen))))
+
 
 (global-set-key (kbd "C-x n w") 'recursive-widen)
 (global-set-key (kbd "C-x n n") 'recursive-narrow-or-widen-dwim)


### PR DESCRIPTION
- Added new custom option `recursive-narrow-dwim-functions'. You can use it like this:
  (defun sacha/recursive-narrow-dwim-org ()
      (cond
       ((not (derived-mode-p 'org-mode)) nil)
       ((or (org-at-block-p)
                  (org-in-src-block-p))
          (org-narrow-to-block)
          t)
       (t (org-narrow-to-subtree) t)))
  (add-hook 'recursive-narrow-dwim-functions 'sacha/recursive-narrow-dwim-org)
- Rewrote the narrow-to-defun function to take advantage of built-in code. Moved the saving of information to a macro for easier wrapping around the dwim-functions.
- Removed need for cl. (I think this should still work...)
